### PR TITLE
Add Gravity support for floating label

### DIFF
--- a/floatlabel/build.gradle
+++ b/floatlabel/build.gradle
@@ -13,8 +13,8 @@ repositories {
 }
 
 android {
-    compileSdkVersion 18
-    buildToolsVersion "19.0.0"
+    compileSdkVersion 19
+    buildToolsVersion "19.0.1"
 
     defaultConfig {
         minSdkVersion 7

--- a/floatlabel/src/main/java/com/micromobs/android/floatlabel/FloatLabelEditText.java
+++ b/floatlabel/src/main/java/com/micromobs/android/floatlabel/FloatLabelEditText.java
@@ -9,6 +9,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.WindowManager;
@@ -20,7 +21,7 @@ import android.widget.TextView;
 @TargetApi(11)
 public class FloatLabelEditText extends LinearLayout {
 
-    private int mFocusedColor, mUnFocusedColor, mFitScreenWidth,
+    private int mFocusedColor, mUnFocusedColor, mFitScreenWidth, mGravity,
                 mCurrentApiVersion = android.os.Build.VERSION.SDK_INT;
     private float mTextSizeInSp;
     private String mHintText, mEditText;
@@ -97,6 +98,7 @@ public class FloatLabelEditText extends LinearLayout {
         mFocusedColor = attributesFromXmlLayout.getColor(R.styleable.FloatLabelEditText_textColorHintFocused, android.R.color.black);
         mUnFocusedColor = attributesFromXmlLayout.getColor(R.styleable.FloatLabelEditText_textColorHintUnFocused, android.R.color.darker_gray);
         mFitScreenWidth = attributesFromXmlLayout.getInt(R.styleable.FloatLabelEditText_fitScreenWidth, 0);
+        mGravity = attributesFromXmlLayout.getInt(R.styleable.FloatLabelEditText_gravity, Gravity.LEFT);
 
         attributesFromXmlLayout.recycle();
     }
@@ -121,6 +123,7 @@ public class FloatLabelEditText extends LinearLayout {
         mFloatingLabel.setText(mHintText);
         mFloatingLabel.setTextColor(mUnFocusedColor);
         mFloatingLabel.setTextSize(TypedValue.COMPLEX_UNIT_SP, (float) (mTextSizeInSp / 1.3));
+        mFloatingLabel.setGravity(mGravity);
 
         mFloatingLabel.setPadding(mEditTextView.getPaddingLeft(), 0, 0, 0);
 

--- a/floatlabel/src/main/res/layout/floatlabel_edittext.xml
+++ b/floatlabel/src/main/res/layout/floatlabel_edittext.xml
@@ -7,7 +7,7 @@
                 android:layout_height="wrap_content">
     <TextView
         android:id="@+id/floating_label_hint"
-        android:layout_width="wrap_content"
+        android:layout_width="fill_parent"
         android:visibility="invisible"
         android:layout_height="wrap_content"
         android:layout_marginBottom="-8dp"/>

--- a/floatlabel/src/main/res/values/attrs.xml
+++ b/floatlabel/src/main/res/values/attrs.xml
@@ -10,5 +10,10 @@
             <enum name="full" value="1"/>
             <enum name="half" value="2"/>
         </attr>
+        <attr name="gravity" format="enum">
+            <enum name="left" value="3" />
+            <enum name="right" value="5" />
+            <enum name="center" value="17" />
+        </attr>
     </declare-styleable>
 </resources>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 android {
     compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    buildToolsVersion "19.0.1"
 
     defaultConfig {
         minSdkVersion 7

--- a/sample/src/main/res/layout/fragment_demo.xml
+++ b/sample/src/main/res/layout/fragment_demo.xml
@@ -32,9 +32,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
 
-        floatlabel:hint="Floating Label 2"
+        floatlabel:hint="Floating Label 2 (Right gravity)"
         floatlabel:text="Text"
         floatlabel:textSize="16sp"
+        floatlabel:gravity="right"
         floatlabel:textColorHintFocused="@color/holo_blue_dark"
         floatlabel:textColorHintUnFocused="@android:color/darker_gray"/>
 
@@ -58,9 +59,10 @@
         android:layout_height="wrap_content"
 
         floatlabel:fitScreenWidth="full"
-        floatlabel:hint="Fit Width (full) Example"
+        floatlabel:hint="Fit Width (full) Example (Center gravity)"
         floatlabel:text="Small txt"
         floatlabel:textSize="16sp"
+        floatlabel:gravity="center"
         floatlabel:textColorHintFocused="@color/holo_blue_dark"
         floatlabel:textColorHintUnFocused="@android:color/darker_gray"/>
 


### PR DESCRIPTION
Now you can use left, right, center gravity for floating label. When using RTL languages such as Persian, Arabic, Hebrew and etc. gravity option might be useful.

![screenshot_2014-02-24-13-24-37](https://f.cloud.github.com/assets/1250691/2244156/060521ee-9d3a-11e3-91c7-e6b90582635d.png)
