### PR TITLE
Setting dimension of containing EditText to match the parent's dimension.

### DIFF
--- a/floatlabel/src/main/res/layout/weddingparty_floatlabel_edittext.xml
+++ b/floatlabel/src/main/res/layout/weddingparty_floatlabel_edittext.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    android:orientation="vertical"
-    android:layout_height="wrap_content"
-    android:layout_width="wrap_content"
-    android:layout_marginTop="5dp"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
 
     <TextView
         android:id="@+id/floating_label_hint"
@@ -16,6 +11,6 @@
     <EditText
         android:id="@+id/floating_label_edit_text"
         android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:hint="tmp"/>
-</LinearLayout>
+</merge>

--- a/floatlabel/src/main/res/values/attrs.xml
+++ b/floatlabel/src/main/res/values/attrs.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="FloatLabelEditText">
-        <attr name="fitScreenWidth" format="enum">
-            <enum name="full" value="1"/>
-            <enum name="half" value="2"/>
-        </attr>
+        <attr name="maxLength" format="integer" min="0" />
         <attr name="gravity" format="enum">
             <enum name="left" value="3"/>
             <enum name="right" value="5"/>


### PR DESCRIPTION
This pull request includes a few things:
- Setting dimension of containing EditText to match the parent's dimension
  - This way the width is not limited to either `half` or `full`, the user can set any arbitrary width to the `FloatLabelEditText` view and the containing `EditText`'s dimens will match that.
- Support for `maxLength`
